### PR TITLE
Add support for DB-IP lite databases

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -161,7 +161,7 @@ impl<'a, T> Reader<'a, T> {
     }
 }
 
-#[reader("GeoIP2-Country", "GeoLite2-Country")]
+#[reader("GeoIP2-Country", "GeoLite2-Country", "DBIP-Country-Lite")]
 #[derive(Default, Debug)]
 pub struct Country<'a> {
     pub continent: Option<models::Continent<'a>>,
@@ -171,7 +171,7 @@ pub struct Country<'a> {
     pub traits: Option<models::Traits>,
 }
 
-#[reader("GeoIP2-City", "GeoLite2-City")]
+#[reader("GeoIP2-City", "GeoLite2-City", "DBIP-City-Lite")]
 #[derive(Default, Debug)]
 pub struct City<'a> {
     pub continent: Option<models::Continent<'a>>,
@@ -225,7 +225,7 @@ pub struct AnonymousIP {
     pub is_residential_proxy: Option<bool>,
 }
 
-#[reader("GeoLite2-ASN")]
+#[reader("GeoLite2-ASN", "DBIP-ASN-Lite", "DBIP-ASN-Lite (compat=GeoLite2-ASN)")]
 #[derive(Default, Debug)]
 pub struct ASN<'a> {
     pub autonomous_system_number: Option<u32>,


### PR DESCRIPTION
DB-IP publish three free databases under CC BY 4.0: [IP to Country Lite](https://db-ip.com/db/download/ip-to-country-lite), [IP to City Lite](https://db-ip.com/db/download/ip-to-city-lite), and [IP to ASN Lite](https://db-ip.com/db/download/ip-to-asn-lite).

Their ASN DB identifies itself as "DBIP-ASN-Lite (compat=GeoLite2-ASN)", I've also added "DBIP-ASN-Lite" in case they make it consistent with their city/country databases later.

I haven't added their paid databases because I don't have them and they don't seem to publish test data, but the [geoip2-golang project](https://github.com/oschwald/geoip2-golang/blob/main/reader.go#L273) has their IDs listed.