### PR TITLE
Add support iter for map

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -174,7 +174,7 @@ impl<'a> Map<'a> {
         None
     }
 
-    pub fn into_iter(&'a self) -> std::slice::Iter<'a, (&'a str, &'a str)> {
+    pub fn iter(&'a self) -> std::slice::Iter<'a, (&'a str, &'a str)> {
         self.0.iter()
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -173,6 +173,10 @@ impl<'a> Map<'a> {
         }
         None
     }
+
+    pub fn into_iter(&'a self) -> std::slice::Iter<'a, (&'a str, &'a str)> {
+        self.0.iter()
+    }
 }
 
 pub(crate) fn read_map<'a>(buffer: &'a [u8], offset: &mut usize) -> Result<Map<'a>, Error> {


### PR DESCRIPTION
This is the primary reason that I am confused when using the module, I can't find out what options there are for enumerations, without bruteforcing. So why not give an iterator without exposing the internal implementation.