### PR TITLE
Upgrade maxminddb in benchmarks to 0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [".", "codegen"]
 geoip2-codegen = { path = "codegen" }
 
 [dev-dependencies]
-maxminddb = "0.24.0"
+maxminddb = "0.27.2"
 
 [profile.release]
 lto = "fat"

--- a/benches/geoip.rs
+++ b/benches/geoip.rs
@@ -32,7 +32,11 @@ mod tests {
         let reader = maxminddb::Reader::open_readfile("./testdata/GeoIP2-Country.mmdb").unwrap();
         let ip = IpAddr::from_str("81.2.69.142").unwrap();
         b.iter(|| {
-            reader.lookup::<maxminddb::geoip2::Country>(ip).unwrap();
+            reader
+                .lookup(ip)
+                .unwrap()
+                .decode::<maxminddb::geoip2::Country>()
+                .unwrap();
         });
     }
 
@@ -41,7 +45,11 @@ mod tests {
         let reader = maxminddb::Reader::open_readfile("./testdata/GeoIP2-City.mmdb").unwrap();
         let ip = IpAddr::from_str("81.2.69.142").unwrap();
         b.iter(|| {
-            reader.lookup::<maxminddb::geoip2::City>(ip).unwrap();
+            reader
+                .lookup(ip)
+                .unwrap()
+                .decode::<maxminddb::geoip2::City>()
+                .unwrap();
         });
     }
 }


### PR DESCRIPTION
I was curious how a more modern `maxminddb` compared. On my machine:

```
test tests::bench_city             ... bench:         872.83 ns/iter (+/- 43.02)
test tests::bench_city_oschwald    ... bench:         748.95 ns/iter (+/- 16.51)
test tests::bench_country          ... bench:         468.07 ns/iter (+/- 22.21)
test tests::bench_country_oschwald ... bench:         399.45 ns/iter (+/- 11.90)
```
The newest version does have `decode_path` as well, which allows more selective decoding if you only need a couple of values and don't want to create your own model structs.
